### PR TITLE
Fix: Resolve broken GitHub link to official website (typo: includes “@”)

### DIFF
--- a/ui/src/lib/layout.shared.tsx
+++ b/ui/src/lib/layout.shared.tsx
@@ -6,7 +6,7 @@ export function baseOptions(): BaseLayoutProps {
     nav: {
       title: "@fydemy/ui",
     },
-    githubUrl: "https://github.com/@fydemy/ui",
+    githubUrl: "https://github.com/fydemy/ui",
     links: [
       {
         icon: <Sparkles className="fill-neutral-500" />,


### PR DESCRIPTION
## Description

This merge request fixes link to official Github repository as reported in #4.

## Changes Made
- Update ```githubUrl``` from ```layout.shared.tsx```

## Related Issue
Closes #4 